### PR TITLE
Homer did not build with libav-9 (and possibly new ffmpeg)

### DIFF
--- a/HomerMultimedia/include/Header_Ffmpeg.h
+++ b/HomerMultimedia/include/Header_Ffmpeg.h
@@ -179,6 +179,18 @@ inline void HM_close_input(AVFormatContext *s)
 	#endif
 }
 
+inline AVStream *HM_avformat_new_stream(AVFormatContext *s, int id)
+{
+	#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(53, 10, 0)
+		return av_new_stream(s, c);
+	#else
+		AVStream *st = avformat_new_stream(s, NULL);
+		if (st)
+			st->id = id;
+		return st;
+	#endif
+}
+
 #if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(51, 35, 0)
 inline int av_opt_set(void *obj, const char *name, const char *val, int search_flags)
 {

--- a/HomerMultimedia/src/MediaSource.cpp
+++ b/HomerMultimedia/src/MediaSource.cpp
@@ -246,11 +246,19 @@ void MediaSource::LogSupportedVideoCodecs(bool pSendToLoggerOnly)
     {
         if (tCodec->type == AVMEDIA_TYPE_VIDEO)
         {
+            #ifndef FF_API_OLD_ENCODE_AUDIO
             bool tEncode = (tCodec->encode != NULL);
+            #else
+            bool tEncode = (tCodec->encode2 != NULL);
+            #endif
             bool tDecode = (tCodec->decode != NULL);
             if ((tNextCodec != NULL) && (strcmp(tCodec->name, tNextCodec->name) == 0))
             {
+                #ifndef FF_API_OLD_ENCODE_AUDIO
                 tEncode |= (tNextCodec->encode != NULL);
+                #else
+                tEncode |= (tNextCodec->encode2 != NULL);
+                #endif
                 tDecode |= (tNextCodec->decode != NULL);
                 tCodec = tNextCodec;
             }
@@ -306,11 +314,19 @@ void MediaSource::LogSupportedAudioCodecs(bool pSendToLoggerOnly)
 //				tNextCodec->encode ? "E" : " ",
 //				tNextCodec->name,
 //				tNextCodec->long_name ? tCodec->long_name : "");
+            #ifndef FF_API_OLD_ENCODE_AUDIO
             bool tEncode = (tCodec->encode != NULL);
+            #else
+            bool tEncode = (tCodec->encode2 != NULL);
+            #endif
             bool tDecode = (tCodec->decode != NULL);
             if ((tNextCodec != NULL) && (strcmp(tCodec->name, tNextCodec->name) == 0))
             {
+                #ifndef FF_API_OLD_ENCODE_AUDIO
                 tEncode |= (tNextCodec->encode != NULL);
+                #else
+                tEncode |= (tNextCodec->encode2 != NULL);
+                #endif
                 tDecode |= (tNextCodec->decode != NULL);
                 tCodec = tNextCodec;
             }
@@ -1709,7 +1725,7 @@ bool MediaSource::StartRecording(std::string pSaveFileName, int pSaveFileQuality
     sprintf(mRecorderFormatContext->filename, "%s", pSaveFileName.c_str());
 
     // allocate new stream structure
-    tStream = av_new_stream(mRecorderFormatContext, 0);
+    tStream = HM_avformat_new_stream(mRecorderFormatContext, 0);
     mRecorderCodecContext = tStream->codec;
 
     // put sample parameters

--- a/HomerMultimedia/src/MediaSourceMuxer.cpp
+++ b/HomerMultimedia/src/MediaSourceMuxer.cpp
@@ -442,7 +442,7 @@ bool MediaSourceMuxer::OpenVideoMuxer(int pResX, int pResY, float pFps)
 
     // allocate new stream structure
     LOG(LOG_VERBOSE, "..allocating new stream");
-    tStream = av_new_stream(mFormatContext, 0);
+    tStream = HM_avformat_new_stream(mFormatContext, 0);
     mCodecContext = tStream->codec;
     mCodecContext->codec_id = tFormat->video_codec;
     mCodecContext->codec_type = AVMEDIA_TYPE_VIDEO;
@@ -737,7 +737,7 @@ bool MediaSourceMuxer::OpenAudioMuxer(int pSampleRate, int pChannels)
     }
 
     // allocate new stream structure
-    tStream = av_new_stream(mFormatContext, 0);
+    tStream = HM_avformat_new_stream(mFormatContext, 0);
     mCodecContext = tStream->codec;
     mCodecContext->codec_id = tFormat->audio_codec;
     mCodecContext->codec_type = AVMEDIA_TYPE_AUDIO;

--- a/HomerMultimedia/src/RTP.cpp
+++ b/HomerMultimedia/src/RTP.cpp
@@ -563,7 +563,7 @@ bool RTP::OpenRtpEncoder(string pTargetHost, unsigned int pTargetPort, AVStream 
     // verbose timestamp debugging    mRtpFormatContext->debug = FF_FDEBUG_TS;
 
     // allocate new stream structure
-	tOuterStream = av_new_stream(mRtpFormatContext, 0);
+	tOuterStream = HM_avformat_new_stream(mRtpFormatContext, 0);
     if (tOuterStream == NULL)
     {
         LOG(LOG_ERROR, "Memory allocation failed");


### PR DESCRIPTION
libav-9 should be unmasked in gentoo-portage tree. the problem was spotted via https://bugs.gentoo.org/show_bug.cgi?id=448718.
